### PR TITLE
Add navigation header and rename pages

### DIFF
--- a/app/architecture/page.tsx
+++ b/app/architecture/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+export default function ArchitecturePage() {
+  return (
+    <div className="relative min-h-screen bg-black text-white flex flex-col items-center justify-center overflow-hidden px-6 py-20">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-900 via-cyan-900 to-black opacity-80" />
+      <div className="absolute -top-40 left-1/2 transform -translate-x-1/2 w-[600px] h-[600px] bg-sky-500 opacity-30 rounded-full blur-[160px] animate-pulse" />
+      <div className="absolute bottom-[-120px] right-[-120px] w-[300px] h-[300px] bg-blue-600 opacity-30 rounded-full blur-[100px]" />
+      <main className="text-center max-w-3xl z-10">
+        <h1 className="text-4xl sm:text-6xl font-extrabold tracking-tight leading-tight bg-gradient-to-r from-white via-cyan-200 to-blue-300 text-transparent bg-clip-text drop-shadow-[0_2px_20px_rgba(255,255,255,0.2)]">
+          아키텍처 – march 프레임워크와 모듈 시스템
+        </h1>
+        <p className="mt-6 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          MARA는 내부적으로 march(modular architecture) 프레임워크 위에 구성되어 있습니다.
+        </p>
+        <p className="mt-4 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          march는 다양한 기능 모듈을 런타임에 불러와 동적으로 연결하고 실행할 수 있도록 설계된 통신 미들웨어입니다. 이를 통해 컴파일 없이 모듈 교체, 모듈 단위 테스트와 병렬 실행, 설정 파일만으로 시스템 구성 변경이 가능합니다.
+        </p>
+        <p className="mt-4 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          모든 모듈은 Module(계산 중심, 일시적 실행)과 RunnableModule(지속적 동작, 별도 스레드 실행) 두 인터페이스 중 하나를 기반으로 작성되며, MARA의 구성 요소는 이를 상속해 독립적으로 구현됩니다.
+        </p>
+        <div className="mt-8">
+          <Link href="/usage" className="underline hover:text-gray-300">
+            다음 페이지 →
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/architecture/page.tsx
+++ b/app/architecture/page.tsx
@@ -1,11 +1,16 @@
 import Link from "next/link";
 
-export default function ArchitecturePage() {
+export default function Page2() {
   return (
     <div className="relative min-h-screen bg-black text-white flex flex-col items-center justify-center overflow-hidden px-6 py-20">
       <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-900 via-cyan-900 to-black opacity-80" />
       <div className="absolute -top-40 left-1/2 transform -translate-x-1/2 w-[600px] h-[600px] bg-sky-500 opacity-30 rounded-full blur-[160px] animate-pulse" />
       <div className="absolute bottom-[-120px] right-[-120px] w-[300px] h-[300px] bg-blue-600 opacity-30 rounded-full blur-[100px]" />
+      <div className="absolute top-4 left-4 z-20">
+        <Link href="/" className="font-semibold hover:underline">
+          MARA
+        </Link>
+      </div>
       <main className="text-center max-w-3xl z-10">
         <h1 className="text-4xl sm:text-6xl font-extrabold tracking-tight leading-tight bg-gradient-to-r from-white via-cyan-200 to-blue-300 text-transparent bg-clip-text drop-shadow-[0_2px_20px_rgba(255,255,255,0.2)]">
           아키텍처 – march 프레임워크와 모듈 시스템
@@ -20,7 +25,7 @@ export default function ArchitecturePage() {
           모든 모듈은 Module(계산 중심, 일시적 실행)과 RunnableModule(지속적 동작, 별도 스레드 실행) 두 인터페이스 중 하나를 기반으로 작성되며, MARA의 구성 요소는 이를 상속해 독립적으로 구현됩니다.
         </p>
         <div className="mt-8">
-          <Link href="/usage" className="underline hover:text-gray-300">
+          <Link href="/overview" className="underline hover:text-gray-300">
             다음 페이지 →
           </Link>
         </div>

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export default function OverviewPage() {
+  return (
+    <div className="relative min-h-screen bg-black text-white flex flex-col items-center justify-center overflow-hidden px-6 py-20">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-900 via-cyan-900 to-black opacity-80" />
+      <div className="absolute -top-40 left-1/2 transform -translate-x-1/2 w-[600px] h-[600px] bg-sky-500 opacity-30 rounded-full blur-[160px] animate-pulse" />
+      <div className="absolute bottom-[-120px] right-[-120px] w-[300px] h-[300px] bg-blue-600 opacity-30 rounded-full blur-[100px]" />
+      <main className="text-center max-w-3xl z-10">
+        <h1 className="text-4xl sm:text-6xl font-extrabold tracking-tight leading-tight bg-gradient-to-r from-white via-cyan-200 to-blue-300 text-transparent bg-clip-text drop-shadow-[0_2px_20px_rgba(255,255,255,0.2)]">
+          개요 – MARA란 무엇인가?
+        </h1>
+        <p className="mt-6 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          MARA(MOdular Architecture for Robot Arms)는 PLAiF에서 개발한 차세대 로봇 제어 아키텍처입니다. 기존 로봇 시스템의 단일 구조와는 달리, 모든 구성 요소를 모듈 단위로 나누어 유연하게 제어할 수 있는 구조를 제공합니다.
+        </p>
+        <p className="mt-4 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          MARA는 로봇 동작 구조의 복잡성, 시스템 구성 변경의 어려움, 유지보수 및 디버깅의 비효율성을 해결하기 위해 모듈화, 런타임 연결, 로컬 최적화 통신이라는 세 가지 핵심 설계를 따릅니다.
+        </p>
+        <div className="mt-8">
+          <Link href="/architecture" className="underline hover:text-gray-300">
+            다음 페이지 →
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -1,11 +1,16 @@
 import Link from "next/link";
 
-export default function OverviewPage() {
+export default function Page1() {
   return (
     <div className="relative min-h-screen bg-black text-white flex flex-col items-center justify-center overflow-hidden px-6 py-20">
       <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-900 via-cyan-900 to-black opacity-80" />
       <div className="absolute -top-40 left-1/2 transform -translate-x-1/2 w-[600px] h-[600px] bg-sky-500 opacity-30 rounded-full blur-[160px] animate-pulse" />
       <div className="absolute bottom-[-120px] right-[-120px] w-[300px] h-[300px] bg-blue-600 opacity-30 rounded-full blur-[100px]" />
+      <div className="absolute top-4 left-4 z-20">
+        <Link href="/" className="font-semibold hover:underline">
+          MARA
+        </Link>
+      </div>
       <main className="text-center max-w-3xl z-10">
         <h1 className="text-4xl sm:text-6xl font-extrabold tracking-tight leading-tight bg-gradient-to-r from-white via-cyan-200 to-blue-300 text-transparent bg-clip-text drop-shadow-[0_2px_20px_rgba(255,255,255,0.2)]">
           개요 – MARA란 무엇인가?
@@ -17,7 +22,7 @@ export default function OverviewPage() {
           MARA는 로봇 동작 구조의 복잡성, 시스템 구성 변경의 어려움, 유지보수 및 디버깅의 비효율성을 해결하기 위해 모듈화, 런타임 연결, 로컬 최적화 통신이라는 세 가지 핵심 설계를 따릅니다.
         </p>
         <div className="mt-8">
-          <Link href="/architecture" className="underline hover:text-gray-300">
+          <Link href="/usage" className="underline hover:text-gray-300">
             다음 페이지 →
           </Link>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
@@ -7,34 +8,11 @@ export default function Home() {
       <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-900 via-cyan-900 to-black opacity-80" />
       <div className="absolute -top-40 left-1/2 transform -translate-x-1/2 w-[600px] h-[600px] bg-sky-500 opacity-30 rounded-full blur-[160px] animate-pulse" />
       <div className="absolute bottom-[-120px] right-[-120px] w-[300px] h-[300px] bg-blue-600 opacity-30 rounded-full blur-[100px]" />
-
-      {/* Top Navigation */}
-      <nav className="absolute top-6 left-0 right-0 flex justify-center gap-4 z-20">
-        <a
-          href="/overview"
-          className="bg-white text-black px-4 py-2 rounded-full text-sm font-semibold hover:bg-cyan-100 transition shadow"
-        >
-          개요
-        </a>
-        <a
-          href="/architecture"
-          className="bg-white text-black px-4 py-2 rounded-full text-sm font-semibold hover:bg-cyan-100 transition shadow"
-        >
-          아키텍처
-        </a>
-        <a
-          href="/usage"
-          className="bg-white text-black px-4 py-2 rounded-full text-sm font-semibold hover:bg-cyan-100 transition shadow"
-        >
-          사용 방식
-        </a>
-        <a
-          href="/usecase"
-          className="bg-white text-black px-4 py-2 rounded-full text-sm font-semibold hover:bg-cyan-100 transition shadow"
-        >
-          활용 사례
-        </a>
-      </nav>
+      <div className="absolute top-4 left-4 z-20">
+        <Link href="/" className="font-semibold hover:underline">
+          MARA
+        </Link>
+      </div>
 
       {/* Content */}
       <main className="text-center max-w-3xl z-10">
@@ -71,6 +49,20 @@ export default function Home() {
             className="border border-white/20 backdrop-blur-md px-6 py-3 rounded-full hover:bg-white/10 transition font-medium"
           >
             Watch Youtube →
+          </a>
+        </div>
+        <div className="mt-8 flex flex-wrap justify-center gap-3">
+          <a href="/overview" className="underline hover:text-gray-300">
+            개요
+          </a>
+          <a href="/architecture" className="underline hover:text-gray-300">
+            아키텍처
+          </a>
+          <a href="/usage" className="underline hover:text-gray-300">
+            사용 방식
+          </a>
+          <a href="/usecase" className="underline hover:text-gray-300">
+            활용 사례
           </a>
         </div>
       </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,34 @@ export default function Home() {
       <div className="absolute -top-40 left-1/2 transform -translate-x-1/2 w-[600px] h-[600px] bg-sky-500 opacity-30 rounded-full blur-[160px] animate-pulse" />
       <div className="absolute bottom-[-120px] right-[-120px] w-[300px] h-[300px] bg-blue-600 opacity-30 rounded-full blur-[100px]" />
 
+      {/* Top Navigation */}
+      <nav className="absolute top-6 left-0 right-0 flex justify-center gap-4 z-20">
+        <a
+          href="/overview"
+          className="bg-white text-black px-4 py-2 rounded-full text-sm font-semibold hover:bg-cyan-100 transition shadow"
+        >
+          개요
+        </a>
+        <a
+          href="/architecture"
+          className="bg-white text-black px-4 py-2 rounded-full text-sm font-semibold hover:bg-cyan-100 transition shadow"
+        >
+          아키텍처
+        </a>
+        <a
+          href="/usage"
+          className="bg-white text-black px-4 py-2 rounded-full text-sm font-semibold hover:bg-cyan-100 transition shadow"
+        >
+          사용 방식
+        </a>
+        <a
+          href="/usecase"
+          className="bg-white text-black px-4 py-2 rounded-full text-sm font-semibold hover:bg-cyan-100 transition shadow"
+        >
+          활용 사례
+        </a>
+      </nav>
+
       {/* Content */}
       <main className="text-center max-w-3xl z-10">
         <Image

--- a/app/usage/page.tsx
+++ b/app/usage/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+export default function UsagePage() {
+  return (
+    <div className="relative min-h-screen bg-black text-white flex flex-col items-center justify-center overflow-hidden px-6 py-20">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-900 via-cyan-900 to-black opacity-80" />
+      <div className="absolute -top-40 left-1/2 transform -translate-x-1/2 w-[600px] h-[600px] bg-sky-500 opacity-30 rounded-full blur-[160px] animate-pulse" />
+      <div className="absolute bottom-[-120px] right-[-120px] w-[300px] h-[300px] bg-blue-600 opacity-30 rounded-full blur-[100px]" />
+      <main className="text-center max-w-3xl z-10">
+        <h1 className="text-4xl sm:text-6xl font-extrabold tracking-tight leading-tight bg-gradient-to-r from-white via-cyan-200 to-blue-300 text-transparent bg-clip-text drop-shadow-[0_2px_20px_rgba(255,255,255,0.2)]">
+          사용 방식 – 구성, 실행, 관리
+        </h1>
+        <p className="mt-6 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          MARA 시스템은 다음 세 가지 구성 요소로 운용됩니다:
+        </p>
+        <p className="mt-4 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          1. 설정 파일(march.yaml) – 각 모듈의 경로, 인자, 연결 관계를 정의합니다.
+        </p>
+        <p className="mt-2 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          2. 실행기(march-runner) – 설정 파일을 읽어 각 모듈을 로딩하고 연결하여 런타임에서 실행합니다.
+        </p>
+        <p className="mt-2 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          3. 모듈 저장소(sw_march_modules) – 모듈 구현을 관리하며 CLI 스크립트를 통해 쉽게 추가·삭제할 수 있습니다.
+        </p>
+        <p className="mt-4 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          CMake 기반 빌드 체인을 통해 모듈을 추가하면 자동으로 빌드 구성이 반영됩니다.
+        </p>
+        <div className="mt-8">
+          <Link href="/usecase" className="underline hover:text-gray-300">
+            다음 페이지 →
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/usage/page.tsx
+++ b/app/usage/page.tsx
@@ -1,11 +1,16 @@
 import Link from "next/link";
 
-export default function UsagePage() {
+export default function Page3() {
   return (
     <div className="relative min-h-screen bg-black text-white flex flex-col items-center justify-center overflow-hidden px-6 py-20">
       <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-900 via-cyan-900 to-black opacity-80" />
       <div className="absolute -top-40 left-1/2 transform -translate-x-1/2 w-[600px] h-[600px] bg-sky-500 opacity-30 rounded-full blur-[160px] animate-pulse" />
       <div className="absolute bottom-[-120px] right-[-120px] w-[300px] h-[300px] bg-blue-600 opacity-30 rounded-full blur-[100px]" />
+      <div className="absolute top-4 left-4 z-20">
+        <Link href="/" className="font-semibold hover:underline">
+          MARA
+        </Link>
+      </div>
       <main className="text-center max-w-3xl z-10">
         <h1 className="text-4xl sm:text-6xl font-extrabold tracking-tight leading-tight bg-gradient-to-r from-white via-cyan-200 to-blue-300 text-transparent bg-clip-text drop-shadow-[0_2px_20px_rgba(255,255,255,0.2)]">
           사용 방식 – 구성, 실행, 관리

--- a/app/usecase/page.tsx
+++ b/app/usecase/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+export default function UseCasePage() {
+  return (
+    <div className="relative min-h-screen bg-black text-white flex flex-col items-center justify-center overflow-hidden px-6 py-20">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-900 via-cyan-900 to-black opacity-80" />
+      <div className="absolute -top-40 left-1/2 transform -translate-x-1/2 w-[600px] h-[600px] bg-sky-500 opacity-30 rounded-full blur-[160px] animate-pulse" />
+      <div className="absolute bottom-[-120px] right-[-120px] w-[300px] h-[300px] bg-blue-600 opacity-30 rounded-full blur-[100px]" />
+      <main className="text-center max-w-3xl z-10">
+        <h1 className="text-4xl sm:text-6xl font-extrabold tracking-tight leading-tight bg-gradient-to-r from-white via-cyan-200 to-blue-300 text-transparent bg-clip-text drop-shadow-[0_2px_20px_rgba(255,255,255,0.2)]">
+          활용 사례 – 양팔 로봇에서의 MARA 적용
+        </h1>
+        <p className="mt-6 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          MARA는 현재 PLAiF의 양팔 로봇 프로젝트에 적용되어 왼팔의 커넥터 삽입 및 체결, 오른팔의 더스트 커버 파지 및 체결 작업을 수행합니다.
+        </p>
+        <p className="mt-4 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          각 동작은 모션 제어, 강화학습 기반 제어, 비전 인식, 장치 인터페이스 등의 모듈로 분리되어 모든 동작을 28초 이내에 완료합니다.
+        </p>
+        <p className="mt-4 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          MARA 도입으로 각 모듈의 독립 디버깅이 가능해 유지보수 효율이 향상되었고, 티칭 펜던트와 연동된 GUI로 현장 운용이 개선되며, 새로운 제어 알고리즘을 플러그인 형태로 적용할 수 있게 되었습니다.
+        </p>
+        <p className="mt-4 text-lg sm:text-xl text-gray-300 leading-relaxed tracking-wide">
+          MARA는 복잡한 작업을 명확한 구조로 나누어 로봇 시스템의 유연성과 확장성을 극대화합니다.
+        </p>
+        <div className="mt-8">
+          <Link href="/" className="underline hover:text-gray-300">
+            홈으로 돌아가기
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/usecase/page.tsx
+++ b/app/usecase/page.tsx
@@ -1,11 +1,16 @@
 import Link from "next/link";
 
-export default function UseCasePage() {
+export default function Page4() {
   return (
     <div className="relative min-h-screen bg-black text-white flex flex-col items-center justify-center overflow-hidden px-6 py-20">
       <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-900 via-cyan-900 to-black opacity-80" />
       <div className="absolute -top-40 left-1/2 transform -translate-x-1/2 w-[600px] h-[600px] bg-sky-500 opacity-30 rounded-full blur-[160px] animate-pulse" />
       <div className="absolute bottom-[-120px] right-[-120px] w-[300px] h-[300px] bg-blue-600 opacity-30 rounded-full blur-[100px]" />
+      <div className="absolute top-4 left-4 z-20">
+        <Link href="/" className="font-semibold hover:underline">
+          MARA
+        </Link>
+      </div>
       <main className="text-center max-w-3xl z-10">
         <h1 className="text-4xl sm:text-6xl font-extrabold tracking-tight leading-tight bg-gradient-to-r from-white via-cyan-200 to-blue-300 text-transparent bg-clip-text drop-shadow-[0_2px_20px_rgba(255,255,255,0.2)]">
           활용 사례 – 양팔 로봇에서의 MARA 적용


### PR DESCRIPTION
## Summary
- rename numbered pages to named routes
- add navigation menu at the top of the home page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ad40921b8832db9e1087990c98565